### PR TITLE
Use the client API to check tx details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,6 +3069,7 @@ dependencies = [
  "color-print",
  "reqwest",
  "safe-utils",
+ "semver 1.0.25",
  "serde",
  "serde_json",
  "sty",

--- a/crates/safe-hash/Cargo.toml
+++ b/crates/safe-hash/Cargo.toml
@@ -18,4 +18,5 @@ tokio.workspace = true
 color-print.workspace = true
 cli-table.workspace = true
 sty.workspace = true
+semver.workspace = true
 safe-utils = { path = "../safe-utils"}

--- a/crates/safe-hash/src/api.rs
+++ b/crates/safe-hash/src/api.rs
@@ -1,7 +1,7 @@
 use alloy::primitives::{Address, ChainId, U256, hex, FixedBytes};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, str::FromStr};
-use crate::{tx_signing::{TxInput, tx_signing_hashes}, cli::TransactionArgs};
+use crate::{cli::TransactionArgs, output::Mismatch, tx_signing::{tx_signing_hashes, TxInput}};
 use safe_utils::SafeWalletVersion;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -97,56 +97,135 @@ pub fn get_safe_transaction(chain_id: u64, safe_address: Address, nonce: u64) ->
 
 pub fn validate_transaction_details(
     api_tx: &SafeTransaction,
-    user_to: Option<Address>,
-    user_value: Option<U256>,
-    user_data: Option<String>,
-) -> Result<(), String> {
-    if let Some(to) = user_to {
+    user_args: &TransactionArgs,
+) -> Result<(), Vec<Mismatch>> {
+    let mut errors = Vec::new();
+
+    if let Some(to) = user_args.to {
         if to != api_tx.to {
-            return Err(format!(
-                "Transaction 'to' address mismatch. API: {}, User provided: {}",
-                api_tx.to, to
-            ));
+            errors.push(Mismatch {
+                field: "to".to_string(),
+                api_value: api_tx.to.to_string(),
+                user_value: to.to_string(),
+            });
         }
     }
 
-    if let Some(value) = user_value {
-        let api_value = U256::from_str_radix(&api_tx.value, 10)
-            .map_err(|e| format!("Failed to parse API value: {}", e))?;
-        if value != api_value {
-            return Err(format!(
-                "Transaction value mismatch. API: {}, User provided: {}",
-                api_value, value
-            ));
+    // If user_args.value is not zero, validate it
+    if user_args.value != U256::ZERO {
+        match U256::from_str_radix(&api_tx.value, 10) {
+            Ok(api_value) => {
+                if user_args.value != api_value {
+                    errors.push(Mismatch {
+                        field: "value".to_string(),
+                        api_value: api_value.to_string(),
+                        user_value: user_args.value.to_string(),
+                    });
+                }
+            }
+            Err(e) => {
+                errors.push(Mismatch {
+                    field: "value".to_string(),
+                    api_value: "".to_string(),
+                    user_value: format!("Failed to parse API value: {}", e),
+                });
+            }
         }
     }
 
-    if let Some(data) = user_data {
-        if data != api_tx.data {
-            return Err(format!(
-                "Transaction data mismatch. API: {}, User provided: {}",
-                api_tx.data, data
-            ));
+    if user_args.data != "0x" {
+        if user_args.data != api_tx.data {
+            errors.push(Mismatch {
+                field: "data".to_string(),
+                api_value: api_tx.data.clone(),
+                user_value: user_args.data.clone(),
+            });
         }
     }
 
-    Ok(())
+    if user_args.operation != api_tx.operation {
+        errors.push(Mismatch {
+            field: "operation".to_string(),
+            api_value: api_tx.operation.to_string(),
+            user_value: user_args.operation.to_string(),
+        });
+    }
+
+    if user_args.gas_token != Address::ZERO {
+        if user_args.gas_token != api_tx.gas_token {
+            errors.push(Mismatch {
+                field: "gas_token".to_string(),
+                api_value: api_tx.gas_token.to_string(),
+                user_value: user_args.gas_token.to_string(),
+            });
+        }
+    }
+
+    if user_args.refund_receiver != Address::ZERO {
+        if user_args.refund_receiver != api_tx.refund_receiver {
+            errors.push(Mismatch {
+                field: "refund_receiver".to_string(),
+                api_value: api_tx.refund_receiver.to_string(),
+                user_value: user_args.refund_receiver.to_string(),
+            });
+        }
+    }
+
+    if user_args.safe_tx_gas != U256::ZERO {
+        if user_args.safe_tx_gas != U256::from(api_tx.safe_tx_gas) {
+            errors.push(Mismatch {
+                field: "safe_tx_gas".to_string(),
+                api_value: api_tx.safe_tx_gas.to_string(),
+                user_value: user_args.safe_tx_gas.to_string(),
+            });
+        }
+    }
+
+    if user_args.base_gas != U256::ZERO {
+        if user_args.base_gas != U256::from(api_tx.base_gas) {
+            errors.push(Mismatch {
+                field: "base_gas".to_string(),
+                api_value: api_tx.base_gas.to_string(),
+                user_value: user_args.base_gas.to_string(),
+            });
+        }
+    }
+
+    if user_args.gas_price != U256::ZERO {
+        if user_args.gas_price != U256::from_str_radix(&api_tx.gas_price, 10).unwrap_or(U256::ZERO) {
+            errors.push(Mismatch {
+                field: "gas_price".to_string(),
+                api_value: api_tx.gas_price.clone(),
+                user_value: user_args.gas_price.to_string(),
+            });
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
 }
 
 pub fn validate_safe_tx_hash(
     api_tx: &SafeTransaction,
     calculated_hash: &FixedBytes<32>,
-) -> Result<(), String> {
+) -> Result<(), Mismatch> {
     // Remove 0x prefix if present and parse as hex
     let api_hash = U256::from_str_radix(api_tx.safe_tx_hash.trim_start_matches("0x"), 16)
-        .map_err(|e| format!("Failed to parse API safe_tx_hash: {}", e))?;
+        .map_err(|e| Mismatch {
+            field: "safe_tx_hash".to_string(),
+            api_value: "".to_string(),
+            user_value: format!("Failed to parse API safe_tx_hash: {}", e),
+        })?;
     let calculated_bytes: [u8; 32] = calculated_hash.as_slice().try_into().unwrap();
     if api_hash != U256::from_be_bytes(calculated_bytes) {
-        return Err(format!(
-            "Safe Transaction Hash mismatch. API: {}, Calculated: {}",
-            api_tx.safe_tx_hash,
-            hex::encode(calculated_hash)
-        ));
+        return Err(Mismatch {
+            field: "safe_tx_hash".to_string(),
+            api_value: api_tx.safe_tx_hash.clone(),
+            user_value: hex::encode(calculated_hash),
+        });
     }
 
     Ok(())
@@ -174,5 +253,195 @@ mod tests {
         assert_eq!(tx.confirmations.len(), 2);
         assert!(tx.is_executed);
         assert!(tx.is_successful);
+    }
+
+    fn create_test_tx() -> SafeTransaction {
+        SafeTransaction {
+            safe: Address::from_str("0x1c694Fc3006D81ff4a56F97E1b99529066a23725").unwrap(),
+            to: Address::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap(),
+            value: "1000000".to_string(),
+            data: "0x1234".to_string(),
+            data_decoded: None,
+            operation: 0,
+            gas_token: Address::ZERO,
+            safe_tx_gas: 100000,
+            base_gas: 50000,
+            gas_price: "1000000000".to_string(),
+            refund_receiver: Address::ZERO,
+            nonce: 1,
+            safe_tx_hash: "0x1234".to_string(),
+            confirmations_required: 2,
+            confirmations: vec![],
+            signatures: "".to_string(),
+            proposer: None,
+            proposed_by_delegate: None,
+            execution_date: None,
+            submission_date: "".to_string(),
+            modified: "".to_string(),
+            block_number: 1,
+            transaction_hash: None,
+            executor: None,
+            is_executed: false,
+            is_successful: false,
+            eth_gas_price: "".to_string(),
+            gas_used: 0,
+            fee: "".to_string(),
+            origin: "".to_string(),
+            trusted: false,
+        }
+    }
+
+    #[test]
+    fn test_validate_transaction_details_no_mismatches() {
+        let api_tx = create_test_tx();
+        let user_args = TransactionArgs {
+            to: Some(api_tx.to),
+            value: U256::from_str_radix(&api_tx.value, 10).unwrap(),
+            data: api_tx.data.clone(),
+            operation: api_tx.operation,
+            gas_token: api_tx.gas_token,
+            safe_tx_gas: U256::from(api_tx.safe_tx_gas),
+            base_gas: U256::from(api_tx.base_gas),
+            gas_price: U256::from_str_radix(&api_tx.gas_price, 10).unwrap(),
+            refund_receiver: api_tx.refund_receiver,
+            ..Default::default()
+        };
+
+        assert!(validate_transaction_details(&api_tx, &user_args).is_ok());
+    }
+
+    #[test]
+    fn test_validate_transaction_details_to_mismatch() {
+        let api_tx = create_test_tx();
+        let mut user_args = TransactionArgs::default();
+        user_args.to = Some(Address::from_str("0x0000000000000000000000000000000000000001").unwrap());
+
+        let result = validate_transaction_details(&api_tx, &user_args).unwrap_err();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].field, "to");
+        assert_eq!(result[0].api_value, api_tx.to.to_string());
+        assert_eq!(result[0].user_value, user_args.to.unwrap().to_string());
+    }
+
+    #[test]
+    fn test_validate_transaction_details_value_mismatch() {
+        let api_tx = create_test_tx();
+        let mut user_args = TransactionArgs::default();
+        user_args.value = U256::from(2000000);
+
+        let result = validate_transaction_details(&api_tx, &user_args).unwrap_err();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].field, "value");
+        assert_eq!(result[0].api_value, api_tx.value);
+        assert_eq!(result[0].user_value, user_args.value.to_string());
+    }
+
+    #[test]
+    fn test_validate_transaction_details_data_mismatch() {
+        let api_tx = create_test_tx();
+        let mut user_args = TransactionArgs::default();
+        user_args.data = "0x5678".to_string();
+
+        let result = validate_transaction_details(&api_tx, &user_args).unwrap_err();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].field, "data");
+        assert_eq!(result[0].api_value, api_tx.data);
+        assert_eq!(result[0].user_value, user_args.data);
+    }
+
+    #[test]
+    fn test_validate_transaction_details_operation_mismatch() {
+        let api_tx = create_test_tx();
+        let mut user_args = TransactionArgs::default();
+        user_args.operation = 1;
+
+        let result = validate_transaction_details(&api_tx, &user_args).unwrap_err();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].field, "operation");
+        assert_eq!(result[0].api_value, api_tx.operation.to_string());
+        assert_eq!(result[0].user_value, user_args.operation.to_string());
+    }
+
+    #[test]
+    fn test_validate_transaction_details_gas_token_mismatch() {
+        let api_tx = create_test_tx();
+        let mut user_args = TransactionArgs::default();
+        user_args.gas_token = Address::from_str("0x0000000000000000000000000000000000000001").unwrap();
+
+        let result = validate_transaction_details(&api_tx, &user_args).unwrap_err();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].field, "gas_token");
+        assert_eq!(result[0].api_value, api_tx.gas_token.to_string());
+        assert_eq!(result[0].user_value, user_args.gas_token.to_string());
+    }
+
+    #[test]
+    fn test_validate_transaction_details_refund_receiver_mismatch() {
+        let api_tx = create_test_tx();
+        let mut user_args = TransactionArgs::default();
+        user_args.refund_receiver = Address::from_str("0x0000000000000000000000000000000000000001").unwrap();
+
+        let result = validate_transaction_details(&api_tx, &user_args).unwrap_err();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].field, "refund_receiver");
+        assert_eq!(result[0].api_value, api_tx.refund_receiver.to_string());
+        assert_eq!(result[0].user_value, user_args.refund_receiver.to_string());
+    }
+
+    #[test]
+    fn test_validate_transaction_details_safe_tx_gas_mismatch() {
+        let api_tx = create_test_tx();
+        let mut user_args = TransactionArgs::default();
+        user_args.safe_tx_gas = U256::from(200000);
+
+        let result = validate_transaction_details(&api_tx, &user_args).unwrap_err();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].field, "safe_tx_gas");
+        assert_eq!(result[0].api_value, api_tx.safe_tx_gas.to_string());
+        assert_eq!(result[0].user_value, user_args.safe_tx_gas.to_string());
+    }
+
+    #[test]
+    fn test_validate_transaction_details_base_gas_mismatch() {
+        let api_tx = create_test_tx();
+        let mut user_args = TransactionArgs::default();
+        user_args.base_gas = U256::from(100000);
+
+        let result = validate_transaction_details(&api_tx, &user_args).unwrap_err();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].field, "base_gas");
+        assert_eq!(result[0].api_value, api_tx.base_gas.to_string());
+        assert_eq!(result[0].user_value, user_args.base_gas.to_string());
+    }
+
+    #[test]
+    fn test_validate_transaction_details_gas_price_mismatch() {
+        let api_tx = create_test_tx();
+        let mut user_args = TransactionArgs::default();
+        user_args.gas_price = U256::from(2000000000);
+
+        let result = validate_transaction_details(&api_tx, &user_args).unwrap_err();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].field, "gas_price");
+        assert_eq!(result[0].api_value, api_tx.gas_price);
+        assert_eq!(result[0].user_value, user_args.gas_price.to_string());
+    }
+
+    #[test]
+    fn test_validate_transaction_details_multiple_mismatches() {
+        let api_tx = create_test_tx();
+        let mut user_args = TransactionArgs::default();
+        user_args.to = Some(Address::from_str("0x0000000000000000000000000000000000000001").unwrap());
+        user_args.value = U256::from(2000000);
+        user_args.data = "0x5678".to_string();
+
+        let result = validate_transaction_details(&api_tx, &user_args).unwrap_err();
+        assert_eq!(result.len(), 3);
+        
+        // Check all mismatches are present
+        let fields: Vec<_> = result.iter().map(|m| &m.field).collect();
+        assert!(fields.contains(&&"to".to_string()));
+        assert!(fields.contains(&&"value".to_string()));
+        assert!(fields.contains(&&"data".to_string()));
     }
 } 

--- a/crates/safe-hash/src/api.rs
+++ b/crates/safe-hash/src/api.rs
@@ -1,0 +1,176 @@
+use alloy::primitives::{Address, U256};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, str::FromStr};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SafeTransaction {
+    pub safe: Address,
+    pub to: Address,
+    pub value: String,
+    pub data: String,
+    #[serde(rename = "dataDecoded")]
+    pub data_decoded: Option<DataDecoded>,
+    pub operation: u8,
+    #[serde(rename = "gasToken")]
+    pub gas_token: Address,
+    #[serde(rename = "safeTxGas")]
+    pub safe_tx_gas: u64,
+    #[serde(rename = "baseGas")]
+    pub base_gas: u64,
+    #[serde(rename = "gasPrice")]
+    pub gas_price: String,
+    #[serde(rename = "refundReceiver")]
+    pub refund_receiver: Address,
+    pub nonce: u64,
+    #[serde(rename = "safeTxHash")]
+    pub safe_tx_hash: String,
+    #[serde(rename = "confirmationsRequired")]
+    pub confirmations_required: u64,
+    pub confirmations: Vec<Confirmation>,
+    pub signatures: String,
+    pub proposer: Option<Address>,
+    #[serde(rename = "proposedByDelegate")]
+    pub proposed_by_delegate: Option<Address>,
+    #[serde(rename = "executionDate")]
+    pub execution_date: Option<String>,
+    #[serde(rename = "submissionDate")]
+    pub submission_date: String,
+    pub modified: String,
+    #[serde(rename = "blockNumber")]
+    pub block_number: u64,
+    #[serde(rename = "transactionHash")]
+    pub transaction_hash: Option<String>,
+    pub executor: Option<Address>,
+    #[serde(rename = "isExecuted")]
+    pub is_executed: bool,
+    #[serde(rename = "isSuccessful")]
+    pub is_successful: bool,
+    #[serde(rename = "ethGasPrice")]
+    pub eth_gas_price: String,
+    #[serde(rename = "gasUsed")]
+    pub gas_used: u64,
+    pub fee: String,
+    pub origin: String,
+    pub trusted: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DataDecoded {
+    pub method: String,
+    pub parameters: Vec<Parameter>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Parameter {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub r#type: String,
+    pub value: String,
+    #[serde(rename = "valueDecoded")]
+    pub value_decoded: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Confirmation {
+    pub owner: Address,
+    #[serde(rename = "submissionDate")]
+    pub submission_date: String,
+    #[serde(rename = "transactionHash")]
+    pub transaction_hash: Option<String>,
+    #[serde(rename = "signatureType")]
+    pub signature_type: String,
+    pub signature: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SafeApiResponse {
+    pub count: u64,
+    pub next: Option<String>,
+    pub previous: Option<String>,
+    pub results: Vec<SafeTransaction>,
+}
+
+const API_BASE_URL: &str = "https://safe-client.safe.global/v1";
+
+pub fn get_safe_transaction(chain_id: u64, safe_address: Address, nonce: u64) -> Result<SafeTransaction, Box<dyn std::error::Error>> {
+    let url = format!(
+        "{}/chains/{}/safes/{}/multisig-transactions/raw?nonce={}",
+        API_BASE_URL, chain_id, safe_address, nonce
+    );
+    println!("Fetching transaction from API: {}", url);
+    let response = reqwest::blocking::get(&url)?;
+    let api_response: SafeApiResponse = response.json()?;
+
+    if api_response.count == 0 {
+        return Err("No transaction found for the specified nonce".into());
+    }
+
+    if api_response.count > 1 {
+        return Err("Multiple transactions found for the specified nonce. Please specify more details to identify the correct transaction.".into());
+    }
+
+    Ok(api_response.results[0].clone())
+}
+
+pub fn validate_transaction_details(
+    api_tx: &SafeTransaction,
+    user_to: Option<Address>,
+    user_value: Option<U256>,
+    user_data: Option<String>,
+) -> Result<(), String> {
+    if let Some(to) = user_to {
+        if to != api_tx.to {
+            return Err(format!(
+                "Transaction 'to' address mismatch. API: {}, User provided: {}",
+                api_tx.to, to
+            ));
+        }
+    }
+
+    if let Some(value) = user_value {
+        let api_value = U256::from_str_radix(&api_tx.value, 10)
+            .map_err(|e| format!("Failed to parse API value: {}", e))?;
+        if value != api_value {
+            return Err(format!(
+                "Transaction value mismatch. API: {}, User provided: {}",
+                api_value, value
+            ));
+        }
+    }
+
+    if let Some(data) = user_data {
+        if data != api_tx.data {
+            return Err(format!(
+                "Transaction data mismatch. API: {}, User provided: {}",
+                api_tx.data, data
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_decode_api_response() {
+        let json = fs::read_to_string("../../test/client_tx_response.json").expect("Failed to read test file");
+        let response: SafeApiResponse = serde_json::from_str(&json).expect("Failed to decode JSON");
+        
+        assert_eq!(response.count, 1);
+        assert_eq!(response.results.len(), 1);
+        
+        let tx = &response.results[0];
+        assert_eq!(tx.safe, Address::from_str("0x1c694Fc3006D81ff4a56F97E1b99529066a23725").unwrap());
+        assert_eq!(tx.to, Address::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap());
+        assert_eq!(tx.value, "0");
+        assert_eq!(tx.nonce, 63);
+        assert_eq!(tx.confirmations_required, 2);
+        assert_eq!(tx.confirmations.len(), 2);
+        assert!(tx.is_executed);
+        assert!(tx.is_successful);
+    }
+} 

--- a/crates/safe-hash/src/api.rs
+++ b/crates/safe-hash/src/api.rs
@@ -1,12 +1,9 @@
 use crate::{
     cli::TransactionArgs,
     output::Mismatch,
-    tx_signing::{TxInput, tx_signing_hashes},
 };
-use alloy::primitives::{Address, ChainId, FixedBytes, U256, hex};
-use safe_utils::SafeWalletVersion;
+use alloy::primitives::{Address, FixedBytes, U256, hex};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, str::FromStr};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -141,14 +138,12 @@ pub fn validate_transaction_details(
         }
     }
 
-    if user_args.data != "0x" {
-        if user_args.data != api_tx.data {
-            errors.push(Mismatch {
-                field: "data".to_string(),
-                api_value: api_tx.data.clone(),
-                user_value: user_args.data.clone(),
-            });
-        }
+    if user_args.data != "0x" && user_args.data != api_tx.data {
+        errors.push(Mismatch {
+            field: "data".to_string(),
+            api_value: api_tx.data.clone(),
+            user_value: user_args.data.clone(),
+        });
     }
 
     if user_args.operation != api_tx.operation {
@@ -159,55 +154,44 @@ pub fn validate_transaction_details(
         });
     }
 
-    if user_args.gas_token != Address::ZERO {
-        if user_args.gas_token != api_tx.gas_token {
-            errors.push(Mismatch {
-                field: "gas_token".to_string(),
-                api_value: api_tx.gas_token.to_string(),
-                user_value: user_args.gas_token.to_string(),
-            });
-        }
+    if user_args.gas_token != Address::ZERO && user_args.gas_token != api_tx.gas_token {
+        errors.push(Mismatch {
+            field: "gas_token".to_string(),
+            api_value: api_tx.gas_token.to_string(),
+            user_value: user_args.gas_token.to_string(),
+        });
     }
 
-    if user_args.refund_receiver != Address::ZERO {
-        if user_args.refund_receiver != api_tx.refund_receiver {
-            errors.push(Mismatch {
-                field: "refund_receiver".to_string(),
-                api_value: api_tx.refund_receiver.to_string(),
-                user_value: user_args.refund_receiver.to_string(),
-            });
-        }
+    if user_args.refund_receiver != Address::ZERO && user_args.refund_receiver != api_tx.refund_receiver {
+        errors.push(Mismatch {
+            field: "refund_receiver".to_string(),
+            api_value: api_tx.refund_receiver.to_string(),
+            user_value: user_args.refund_receiver.to_string(),
+        });
     }
 
-    if user_args.safe_tx_gas != U256::ZERO {
-        if user_args.safe_tx_gas != U256::from(api_tx.safe_tx_gas) {
-            errors.push(Mismatch {
-                field: "safe_tx_gas".to_string(),
-                api_value: api_tx.safe_tx_gas.to_string(),
-                user_value: user_args.safe_tx_gas.to_string(),
-            });
-        }
+    if user_args.safe_tx_gas != U256::ZERO && user_args.safe_tx_gas != U256::from(api_tx.safe_tx_gas) {
+        errors.push(Mismatch {
+            field: "safe_tx_gas".to_string(),
+            api_value: api_tx.safe_tx_gas.to_string(),
+            user_value: user_args.safe_tx_gas.to_string(),
+        });
     }
 
-    if user_args.base_gas != U256::ZERO {
-        if user_args.base_gas != U256::from(api_tx.base_gas) {
-            errors.push(Mismatch {
-                field: "base_gas".to_string(),
-                api_value: api_tx.base_gas.to_string(),
-                user_value: user_args.base_gas.to_string(),
-            });
-        }
+    if user_args.base_gas != U256::ZERO && user_args.base_gas != U256::from(api_tx.base_gas) {
+        errors.push(Mismatch {
+            field: "base_gas".to_string(),
+            api_value: api_tx.base_gas.to_string(),
+            user_value: user_args.base_gas.to_string(),
+        });
     }
 
-    if user_args.gas_price != U256::ZERO {
-        if user_args.gas_price != U256::from_str_radix(&api_tx.gas_price, 10).unwrap_or(U256::ZERO)
-        {
-            errors.push(Mismatch {
-                field: "gas_price".to_string(),
-                api_value: api_tx.gas_price.clone(),
-                user_value: user_args.gas_price.to_string(),
-            });
-        }
+    if user_args.gas_price != U256::ZERO && user_args.gas_price != U256::from_str_radix(&api_tx.gas_price, 10).unwrap_or(U256::ZERO) {
+        errors.push(Mismatch {
+            field: "gas_price".to_string(),
+            api_value: api_tx.gas_price.clone(),
+            user_value: user_args.gas_price.to_string(),
+        });
     }
 
     if errors.is_empty() { Ok(()) } else { Err(errors) }
@@ -243,6 +227,7 @@ mod tests {
     use super::*;
     use std::fs;
 
+    use std::str::FromStr;
     #[test]
     fn test_decode_api_response() {
         let json = fs::read_to_string("../../test/client_tx_response.json")

--- a/crates/safe-hash/src/api.rs
+++ b/crates/safe-hash/src/api.rs
@@ -3,51 +3,35 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, str::FromStr};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SafeTransaction {
     pub safe: Address,
     pub to: Address,
     pub value: String,
     pub data: String,
-    #[serde(rename = "dataDecoded")]
     pub data_decoded: Option<DataDecoded>,
     pub operation: u8,
-    #[serde(rename = "gasToken")]
     pub gas_token: Address,
-    #[serde(rename = "safeTxGas")]
     pub safe_tx_gas: u64,
-    #[serde(rename = "baseGas")]
     pub base_gas: u64,
-    #[serde(rename = "gasPrice")]
     pub gas_price: String,
-    #[serde(rename = "refundReceiver")]
     pub refund_receiver: Address,
     pub nonce: u64,
-    #[serde(rename = "safeTxHash")]
     pub safe_tx_hash: String,
-    #[serde(rename = "confirmationsRequired")]
     pub confirmations_required: u64,
     pub confirmations: Vec<Confirmation>,
     pub signatures: String,
     pub proposer: Option<Address>,
-    #[serde(rename = "proposedByDelegate")]
     pub proposed_by_delegate: Option<Address>,
-    #[serde(rename = "executionDate")]
     pub execution_date: Option<String>,
-    #[serde(rename = "submissionDate")]
     pub submission_date: String,
     pub modified: String,
-    #[serde(rename = "blockNumber")]
     pub block_number: u64,
-    #[serde(rename = "transactionHash")]
     pub transaction_hash: Option<String>,
     pub executor: Option<Address>,
-    #[serde(rename = "isExecuted")]
     pub is_executed: bool,
-    #[serde(rename = "isSuccessful")]
     pub is_successful: bool,
-    #[serde(rename = "ethGasPrice")]
     pub eth_gas_price: String,
-    #[serde(rename = "gasUsed")]
     pub gas_used: u64,
     pub fee: String,
     pub origin: String,
@@ -61,23 +45,20 @@ pub struct DataDecoded {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Parameter {
     pub name: String,
-    #[serde(rename = "type")]
     pub r#type: String,
     pub value: String,
-    #[serde(rename = "valueDecoded")]
     pub value_decoded: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Confirmation {
     pub owner: Address,
-    #[serde(rename = "submissionDate")]
     pub submission_date: String,
-    #[serde(rename = "transactionHash")]
     pub transaction_hash: Option<String>,
-    #[serde(rename = "signatureType")]
     pub signature_type: String,
     pub signature: String,
 }

--- a/crates/safe-hash/src/cli.rs
+++ b/crates/safe-hash/src/cli.rs
@@ -42,8 +42,8 @@ pub struct TransactionArgs {
     pub safe_version: SafeWalletVersion,
 
     /// Address of the contract to which the safe-address sends calldata to.
-    #[arg(short, long, required = true)]
-    pub to: Address,
+    #[arg(short, long)]
+    pub to: Option<Address>,
 
     /// Value asked in the transaction (relates to eth)
     #[arg(long, default_value_t = U256::ZERO)]
@@ -164,7 +164,7 @@ mod tests {
                 tx_args.safe_address,
                 address!("0x1234567890123456789012345678901234567890")
             );
-            assert_eq!(tx_args.to, address!("0x2234567890123456789012345678901234567890"));
+            assert_eq!(tx_args.to, Some(address!("0x2234567890123456789012345678901234567890")));
             assert_eq!(tx_args.value, U256::from(0));
             assert_eq!(tx_args.data, "0xabcd");
         } else {

--- a/crates/safe-hash/src/cli.rs
+++ b/crates/safe-hash/src/cli.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, ChainId, U256};
+use alloy::primitives::{Address, U256};
 use clap::{Parser, Subcommand};
 use safe_utils::{SafeWalletVersion, get_all_supported_chain_names};
 use semver::Version;

--- a/crates/safe-hash/src/cli.rs
+++ b/crates/safe-hash/src/cli.rs
@@ -1,6 +1,7 @@
-use alloy::primitives::{Address, U256};
+use alloy::primitives::{Address, ChainId, U256};
 use clap::{Parser, Subcommand};
 use safe_utils::{SafeWalletVersion, get_all_supported_chain_names};
+use semver::Version;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -71,6 +72,26 @@ pub struct TransactionArgs {
 
     #[arg(long, default_value_t = Address::ZERO)]
     pub refund_receiver: Address,
+}
+
+impl Default for TransactionArgs {
+    fn default() -> Self {
+        Self {
+            to: None,
+            value: U256::ZERO,
+            data: "0x".to_string(),
+            operation: 0,
+            gas_token: Address::ZERO,
+            safe_tx_gas: U256::ZERO,
+            base_gas: U256::ZERO,
+            gas_price: U256::ZERO,
+            refund_receiver: Address::ZERO,
+            nonce: 0,
+            safe_address: Address::ZERO,
+            chain: "ethereum".to_string(),
+            safe_version: Version::new(1, 3, 0),
+        }
+    }
 }
 
 #[derive(Parser, Debug)]

--- a/crates/safe-hash/src/main.rs
+++ b/crates/safe-hash/src/main.rs
@@ -10,7 +10,7 @@ use alloy::primitives::{Address, ChainId, U256};
 use clap::Parser;
 use cli::{CliArgs, Mode};
 use msg_signing::*;
-use output::{display_api_transaction_details, display_hashes, display_warnings, SafeWarnings};
+use output::{SafeWarnings, display_api_transaction_details, display_hashes, display_warnings};
 use safe_utils::{Of, SafeWalletVersion};
 use std::{fs, str::FromStr};
 use tx_signing::*;
@@ -47,10 +47,7 @@ fn main() {
                 display_api_transaction_details(api_tx);
 
                 // Validate that user-provided details match API data if any were provided
-                if let Err(errors) = api::validate_transaction_details(
-                    api_tx,
-                    &tx_args
-                ) {
+                if let Err(errors) = api::validate_transaction_details(api_tx, &tx_args) {
                     warnings.argument_mismatches.extend(errors);
                 }
 
@@ -86,12 +83,8 @@ fn main() {
             };
 
             // Calculate hashes
-            let hashes = tx_signing_hashes(
-                &tx_data,
-                &tx_args,
-                chain_id,
-                tx_args.safe_version.clone(),
-            );
+            let hashes =
+                tx_signing_hashes(&tx_data, &tx_args, chain_id, tx_args.safe_version.clone());
 
             // Validate Safe Transaction Hash against API data if available
             if let Some(api_tx) = &api_tx {
@@ -117,8 +110,7 @@ fn main() {
             let message = fs::read_to_string(&msg_args.input_file)
                 .unwrap_or_else(|_| panic!("Failed to read message file: {}", msg_args.input_file));
             let msg_data = MsgInput::new(message);
-            let hashes =
-                msg_signing_hashes(&msg_data, &msg_args, chain_id);
+            let hashes = msg_signing_hashes(&msg_data, &msg_args, chain_id);
             display_hashes(&hashes);
         }
     }

--- a/crates/safe-hash/src/main.rs
+++ b/crates/safe-hash/src/main.rs
@@ -47,13 +47,11 @@ fn main() {
                 display_api_transaction_details(api_tx);
 
                 // Validate that user-provided details match API data if any were provided
-                if let Err(e) = api::validate_transaction_details(
+                if let Err(errors) = api::validate_transaction_details(
                     api_tx,
-                    tx_args.to,
-                    if tx_args.value != U256::ZERO { Some(tx_args.value) } else { None },
-                    if tx_args.data != "0x" { Some(tx_args.data.clone()) } else { None },
+                    &tx_args
                 ) {
-                    warnings.argument_mismatches.push(e);
+                    warnings.argument_mismatches.extend(errors);
                 }
 
                 // Use API data for transaction

--- a/crates/safe-hash/src/main.rs
+++ b/crates/safe-hash/src/main.rs
@@ -120,7 +120,7 @@ fn main() {
                 .unwrap_or_else(|_| panic!("Failed to read message file: {}", msg_args.input_file));
             let msg_data = MsgInput::new(message);
             let hashes =
-                msg_signing_hashes(&msg_data, &msg_args, chain_id, SafeWalletVersion::new(1, 3, 0));
+                msg_signing_hashes(&msg_data, &msg_args, chain_id);
             display_hashes(&hashes);
         }
     }

--- a/crates/safe-hash/src/main.rs
+++ b/crates/safe-hash/src/main.rs
@@ -6,13 +6,13 @@ mod output;
 mod tx_signing;
 mod warn;
 
-use alloy::primitives::{Address, ChainId, U256};
+use alloy::primitives::{ChainId, U256};
 use clap::Parser;
 use cli::{CliArgs, Mode};
 use msg_signing::*;
 use output::{SafeWarnings, display_api_transaction_details, display_hashes, display_warnings};
-use safe_utils::{Of, SafeWalletVersion};
-use std::{fs, str::FromStr};
+use safe_utils::Of;
+use std::fs;
 use tx_signing::*;
 use warn::check_suspicious_content;
 
@@ -29,7 +29,7 @@ fn main() {
 
             // Try to get transaction details from API
             let api_tx = match api::get_safe_transaction(
-                chain_id as u64,
+                chain_id,
                 tx_args.safe_address,
                 tx_args.nonce as u64,
             ) {

--- a/crates/safe-hash/src/main.rs
+++ b/crates/safe-hash/src/main.rs
@@ -95,6 +95,13 @@ fn main() {
                 tx_args.safe_version.clone(),
             );
 
+            // Validate Safe Transaction Hash against API data if available
+            if let Some(api_tx) = &api_tx {
+                if let Err(e) = api::validate_safe_tx_hash(api_tx, &hashes.safe_tx_hash) {
+                    warnings.argument_mismatches.push(e);
+                }
+            }
+
             // Display hashes
             display_hashes(&hashes);
 

--- a/crates/safe-hash/src/main.rs
+++ b/crates/safe-hash/src/main.rs
@@ -105,6 +105,9 @@ fn main() {
             // Display hashes
             display_hashes(&hashes);
 
+            // Check for suspicious content and union warnings
+            warnings.union(check_suspicious_content(&tx_data, Some(chain_id)));
+
             // Display warnings after the hashes
             display_warnings(&warnings);
         }

--- a/crates/safe-hash/src/main.rs
+++ b/crates/safe-hash/src/main.rs
@@ -73,7 +73,7 @@ fn main() {
                 // Use user-provided data for transaction
                 TxInput::new(
                     tx_args.to.unwrap_or_else(|| {
-                        panic!("'to' address is required in offline mode")
+                        panic!("'--to' address is required in offline mode. When API data cannot be fetched, you must provide the destination address manually.")
                     }),
                     tx_args.value,
                     tx_args.data.clone(),

--- a/crates/safe-hash/src/msg_signing.rs
+++ b/crates/safe-hash/src/msg_signing.rs
@@ -1,6 +1,6 @@
 use crate::{cli::MessageArgs, output::SafeHashes};
 use alloy::primitives::ChainId;
-use safe_utils::{DomainHasher, MessageHasher, SafeHasher, SafeWalletVersion};
+use safe_utils::{DomainHasher, MessageHasher, SafeHasher};
 
 pub struct MsgInput {
     pub message: String,

--- a/crates/safe-hash/src/msg_signing.rs
+++ b/crates/safe-hash/src/msg_signing.rs
@@ -17,11 +17,10 @@ pub fn msg_signing_hashes(
     msg_data: &MsgInput,
     args: &MessageArgs,
     chain_id: ChainId,
-    safe_version: SafeWalletVersion,
 ) -> SafeHashes {
     // Calculate hashes
     let domain_hash = {
-        let domain_hasher = DomainHasher::new(safe_version.clone(), chain_id, args.safe_address);
+        let domain_hasher = DomainHasher::new(args.safe_version.clone(), chain_id, args.safe_address);
         domain_hasher.hash()
     };
 
@@ -66,7 +65,7 @@ mod tests {
         let msg_data = MsgInput::new(message);
         let chain_id = ChainId::of("sepolia").unwrap();
         let hashes =
-            msg_signing_hashes(&msg_data, &args, chain_id, SafeWalletVersion::new(1, 3, 0));
+            msg_signing_hashes(&msg_data, &args, chain_id);
 
         // Note: These expected values are placeholders and need to be replaced with actual values
         // from a known good test case

--- a/crates/safe-hash/src/msg_signing.rs
+++ b/crates/safe-hash/src/msg_signing.rs
@@ -20,7 +20,8 @@ pub fn msg_signing_hashes(
 ) -> SafeHashes {
     // Calculate hashes
     let domain_hash = {
-        let domain_hasher = DomainHasher::new(args.safe_version.clone(), chain_id, args.safe_address);
+        let domain_hasher =
+            DomainHasher::new(args.safe_version.clone(), chain_id, args.safe_address);
         domain_hasher.hash()
     };
 
@@ -64,8 +65,7 @@ mod tests {
             .unwrap_or_else(|_| panic!("Failed to read message file: {}", args.input_file));
         let msg_data = MsgInput::new(message);
         let chain_id = ChainId::of("sepolia").unwrap();
-        let hashes =
-            msg_signing_hashes(&msg_data, &args, chain_id);
+        let hashes = msg_signing_hashes(&msg_data, &args, chain_id);
 
         // Note: These expected values are placeholders and need to be replaced with actual values
         // from a known good test case

--- a/crates/safe-hash/src/output.rs
+++ b/crates/safe-hash/src/output.rs
@@ -40,6 +40,76 @@ impl SafeWarnings {
     }
 }
 
+pub fn display_api_transaction_details(tx: &crate::api::SafeTransaction) {
+    let mut table_rows = Vec::new();
+
+    // Add basic transaction details
+    table_rows.push(vec![cstr!("<green>Safe Address</>").cell(), tx.safe.to_string().cell()]);
+    table_rows.push(vec![cstr!("<green>To</>").cell(), tx.to.to_string().cell()]);
+    table_rows.push(vec![cstr!("<green>Value</>").cell(), tx.value.clone().cell()]);
+    table_rows.push(vec![cstr!("<green>Data</>").cell(), tx.data.clone().cell()]);
+    table_rows.push(vec![cstr!("<green>Operation</>").cell(), tx.operation.to_string().cell()]);
+    table_rows.push(vec![cstr!("<green>Nonce</>").cell(), tx.nonce.to_string().cell()]);
+
+    // Add gas details
+    table_rows.push(vec![cstr!("<green>Safe Tx Gas</>").cell(), tx.safe_tx_gas.to_string().cell()]);
+    table_rows.push(vec![cstr!("<green>Base Gas</>").cell(), tx.base_gas.to_string().cell()]);
+    table_rows.push(vec![cstr!("<green>Gas Price</>").cell(), tx.gas_price.clone().cell()]);
+    table_rows.push(vec![cstr!("<green>Gas Token</>").cell(), tx.gas_token.to_string().cell()]);
+    table_rows.push(vec![cstr!("<green>Refund Receiver</>").cell(), tx.refund_receiver.to_string().cell()]);
+
+    // Add confirmation details
+    table_rows.push(vec![cstr!("<green>Confirmations Required</>").cell(), tx.confirmations_required.to_string().cell()]);
+    table_rows.push(vec![cstr!("<green>Confirmations Count</>").cell(), tx.confirmations.len().to_string().cell()]);
+
+    // Add decoded data if available
+    if let Some(decoded) = &tx.data_decoded {
+        // Create parameters table with method and parameters
+        let mut param_rows = Vec::new();
+        param_rows.push(vec![
+            cstr!("<blue>Method</>").cell(),
+            decoded.method.clone().cell(),
+        ]);
+        
+        for param in &decoded.parameters {
+            param_rows.push(vec![
+                cstr!("<blue>Parameter</>").cell(),
+                format!("{}: {}", param.r#type, param.value).cell(),
+            ]);
+        }
+        
+        // Print the main transaction details table
+        let table = table_rows.table()
+            .title(vec![
+                cstr!("<cyan>FIELD</>").cell().bold(true),
+                cstr!("<cyan>VALUE</>").cell().bold(true),
+            ])
+            .bold(true);
+        println!("{}", table.display().unwrap());
+        
+        // Print the parameters table if we have any
+        if !param_rows.is_empty() {
+            println!(); // Add spacing between tables
+            let param_table = param_rows.table()
+                .title(vec![
+                    cstr!("<cyan>SELECTOR</>").cell().bold(true),
+                    cstr!("<cyan>VALUE</>").cell().bold(true),
+                ])
+                .bold(true);
+            println!("{}", param_table.display().unwrap());
+        }
+    } else {
+        // If no decoded data, just print the main table
+        let table = table_rows.table()
+            .title(vec![
+                cstr!("<cyan>FIELD</>").cell().bold(true),
+                cstr!("<cyan>VALUE</>").cell().bold(true),
+            ])
+            .bold(true);
+        println!("{}", table.display().unwrap());
+    }
+}
+
 pub fn display_hashes(hashes: &SafeHashes) {
     let mut table_rows = Vec::new();
 
@@ -64,7 +134,7 @@ pub fn display_hashes(hashes: &SafeHashes) {
     let table = table_rows
         .table()
         .title(vec![
-            cstr!("<cyan>TYPE</>").cell().bold(true),
+            cstr!("<cyan>HASH TYPE</>").cell().bold(true),
             cstr!("<cyan>CALCULATED HASHES</cyan>").cell().bold(true),
         ])
         .bold(true);

--- a/crates/safe-hash/src/output.rs
+++ b/crates/safe-hash/src/output.rs
@@ -41,6 +41,19 @@ impl SafeWarnings {
             || self.non_zero_refund_receiver
             || !self.argument_mismatches.is_empty()
     }
+
+    pub fn union(&mut self, other: Self) {
+        // Merge boolean flags using OR
+        self.zero_address |= other.zero_address;
+        self.zero_value |= other.zero_value;
+        self.empty_data |= other.empty_data;
+        self.delegatecall |= other.delegatecall;
+        self.non_zero_gas_token |= other.non_zero_gas_token;
+        self.non_zero_refund_receiver |= other.non_zero_refund_receiver;
+        
+        // Merge vectors using extend
+        self.argument_mismatches.extend(other.argument_mismatches);
+    }
 }
 
 pub fn display_api_transaction_details(tx: &crate::api::SafeTransaction) {

--- a/crates/safe-hash/src/output.rs
+++ b/crates/safe-hash/src/output.rs
@@ -217,7 +217,7 @@ pub fn display_warnings(warnings: &SafeWarnings) {
                     .table()
                     .title(vec![
                         cstr!("").cell().bold(true),
-                        format!("{}", mismatch.field).cell().bold(true),
+                        mismatch.field.to_string().cell().bold(true),
                     ])
                     .bold(true);
                 println!("{}", mismatch_table.display().unwrap());

--- a/crates/safe-hash/src/output.rs
+++ b/crates/safe-hash/src/output.rs
@@ -56,8 +56,6 @@ impl SafeWarnings {
         self.delegatecall |= other.delegatecall;
         self.non_zero_gas_token |= other.non_zero_gas_token;
         self.non_zero_refund_receiver |= other.non_zero_refund_receiver;
-
-        // Merge vectors using extend
         self.argument_mismatches.extend(other.argument_mismatches);
     }
 }

--- a/crates/safe-hash/src/output.rs
+++ b/crates/safe-hash/src/output.rs
@@ -56,7 +56,7 @@ impl SafeWarnings {
         self.delegatecall |= other.delegatecall;
         self.non_zero_gas_token |= other.non_zero_gas_token;
         self.non_zero_refund_receiver |= other.non_zero_refund_receiver;
-        
+
         // Merge vectors using extend
         self.argument_mismatches.extend(other.argument_mismatches);
     }
@@ -74,45 +74,54 @@ pub fn display_api_transaction_details(tx: &crate::api::SafeTransaction) {
     table_rows.push(vec![cstr!("<yellow>Nonce</>").cell(), tx.nonce.to_string().cell()]);
 
     // Add gas details
-    table_rows.push(vec![cstr!("<yellow>Safe Tx Gas</>").cell(), tx.safe_tx_gas.to_string().cell()]);
+    table_rows
+        .push(vec![cstr!("<yellow>Safe Tx Gas</>").cell(), tx.safe_tx_gas.to_string().cell()]);
     table_rows.push(vec![cstr!("<yellow>Base Gas</>").cell(), tx.base_gas.to_string().cell()]);
     table_rows.push(vec![cstr!("<yellow>Gas Price</>").cell(), tx.gas_price.clone().cell()]);
     table_rows.push(vec![cstr!("<yellow>Gas Token</>").cell(), tx.gas_token.to_string().cell()]);
-    table_rows.push(vec![cstr!("<yellow>Refund Receiver</>").cell(), tx.refund_receiver.to_string().cell()]);
+    table_rows.push(vec![
+        cstr!("<yellow>Refund Receiver</>").cell(),
+        tx.refund_receiver.to_string().cell(),
+    ]);
 
     // Add confirmation details
-    table_rows.push(vec![cstr!("<yellow>Confirmations Required</>").cell(), tx.confirmations_required.to_string().cell()]);
-    table_rows.push(vec![cstr!("<yellow>Confirmations Count</>").cell(), tx.confirmations.len().to_string().cell()]);
+    table_rows.push(vec![
+        cstr!("<yellow>Confirmations Required</>").cell(),
+        tx.confirmations_required.to_string().cell(),
+    ]);
+    table_rows.push(vec![
+        cstr!("<yellow>Confirmations Count</>").cell(),
+        tx.confirmations.len().to_string().cell(),
+    ]);
 
     // Add decoded data if available
     if let Some(decoded) = &tx.data_decoded {
         // Create parameters table with method and parameters
         let mut param_rows = Vec::new();
-        param_rows.push(vec![
-            cstr!("<blue>Method</>").cell(),
-            decoded.method.clone().cell(),
-        ]);
-        
+        param_rows.push(vec![cstr!("<blue>Method</>").cell(), decoded.method.clone().cell()]);
+
         for param in &decoded.parameters {
             param_rows.push(vec![
                 cstr!("<blue>Parameter</>").cell(),
                 format!("{}: {}", param.r#type, param.value).cell(),
             ]);
         }
-        
+
         // Print the main transaction details table
-        let table = table_rows.table()
+        let table = table_rows
+            .table()
             .title(vec![
                 cstr!("<cyan>FIELD</>").cell().bold(true),
                 cstr!("<cyan>VALUE</>").cell().bold(true),
             ])
             .bold(true);
         println!("{}", table.display().unwrap());
-        
+
         // Print the parameters table if we have any
         if !param_rows.is_empty() {
             println!(); // Add spacing between tables
-            let param_table = param_rows.table()
+            let param_table = param_rows
+                .table()
                 .title(vec![
                     cstr!("<cyan>SELECTOR</>").cell().bold(true),
                     cstr!("<cyan>VALUE</>").cell().bold(true),
@@ -122,7 +131,8 @@ pub fn display_api_transaction_details(tx: &crate::api::SafeTransaction) {
         }
     } else {
         // If no decoded data, just print the main table
-        let table = table_rows.table()
+        let table = table_rows
+            .table()
             .title(vec![
                 cstr!("<cyan>FIELD</>").cell().bold(true),
                 cstr!("<cyan>VALUE</>").cell().bold(true),
@@ -173,7 +183,7 @@ pub fn display_warnings(warnings: &SafeWarnings) {
     if warnings.has_warnings() {
         println!(); // Add spacing before warnings
         cprintln!("<bold><red>⚠️  WARNINGS:</red></bold>");
-        
+
         // Display standard warnings
         if warnings.zero_address {
             cprintln!("• Transaction is being sent to the zero address");
@@ -197,30 +207,28 @@ pub fn display_warnings(warnings: &SafeWarnings) {
         // Display argument mismatches prominently
         if !warnings.argument_mismatches.is_empty() {
             cprintln!("<bold><red>🚨 ARGUMENT MISMATCHES:</red></bold>");
-            
+
             for mismatch in &warnings.argument_mismatches {
-                
                 // Parse the mismatch message to extract API and user values
                 let mut mismatch_rows = Vec::new();
-                mismatch_rows.push(vec![
-                    "API Returned".cell(),
-                    mismatch.api_value.to_string().cell(),
-                ]);
-                mismatch_rows.push(vec![
-                    "User Supplied".cell(),
-                    mismatch.user_value.to_string().cell(),
-                ]);
-                let mismatch_table = mismatch_rows.table()
-                .title(vec![
-                    cstr!("").cell().bold(true),
-                    format!("{}", mismatch.field).cell().bold(true),
-                ])
-                .bold(true);
+                mismatch_rows
+                    .push(vec!["API Returned".cell(), mismatch.api_value.to_string().cell()]);
+                mismatch_rows
+                    .push(vec!["User Supplied".cell(), mismatch.user_value.to_string().cell()]);
+                let mismatch_table = mismatch_rows
+                    .table()
+                    .title(vec![
+                        cstr!("").cell().bold(true),
+                        format!("{}", mismatch.field).cell().bold(true),
+                    ])
+                    .bold(true);
                 println!("{}", mismatch_table.display().unwrap());
             }
         }
 
         println!(); // Add spacing after warnings
-        cprintln!("<bold><red>Please review the above warnings before signing the transaction.</red></bold>");
+        cprintln!(
+            "<bold><red>Please review the above warnings before signing the transaction.</red></bold>"
+        );
     }
 }

--- a/crates/safe-hash/src/tx_signing.rs
+++ b/crates/safe-hash/src/tx_signing.rs
@@ -118,7 +118,7 @@ mod tests {
             nonce,
             safe_address,
             safe_version: SafeWalletVersion::new(1, 3, 0),
-            to: to_address,
+            to: Some(to_address),
             value: U256::ZERO,
             data: data.clone(),
             operation: 0,

--- a/crates/safe-hash/src/warn.rs
+++ b/crates/safe-hash/src/warn.rs
@@ -1,8 +1,5 @@
 use crate::{etherscan::is_contract_verfied, output::SafeWarnings, tx_signing::TxInput};
-use alloy::{
-    hex,
-    primitives::{Address, ChainId, U256, keccak256},
-};
+use alloy::primitives::{Address, ChainId, U256};
 use std::env::VarError;
 
 pub fn check_suspicious_content(tx_data: &TxInput, chain_id: Option<ChainId>) -> SafeWarnings {

--- a/crates/safe-hash/src/warn.rs
+++ b/crates/safe-hash/src/warn.rs
@@ -28,12 +28,6 @@ pub fn check_suspicious_content(tx_data: &TxInput, chain_id: Option<ChainId>) ->
         // We could add one if needed
     }
 
-    // Check calldata
-    if is_suspicous_calldata(tx_data.data.clone()) {
-        // Note: We don't have a field for suspicious calldata in SafeWarnings
-        // We could add one if needed
-    }
-
     // Check `to` address contract verification status
     if !tx_data.value.is_zero() {
         match chain_id.map(|chain_id| is_contract_verfied(&tx_data.to.to_string(), chain_id)) {
@@ -56,41 +50,4 @@ pub fn check_suspicious_content(tx_data: &TxInput, chain_id: Option<ChainId>) ->
     }
 
     warnings
-}
-
-const SUSPICIOUS_FUNC_SIGNATURES: &[&str] = &[
-    "addOwnerWithThreshold(address,uint256)",
-    "removeOwner(address,address,uint256)",
-    "swapOwner(address,address,address)",
-    "changeThreshold(uint256)",
-];
-
-fn is_suspicous_calldata(calldata: String) -> bool {
-    let suspicous_func_selectors = SUSPICIOUS_FUNC_SIGNATURES
-        .iter()
-        .map(|s| {
-            let func_hash = keccak256(s);
-            func_hash[..4].to_vec()
-        })
-        .collect::<Vec<_>>();
-
-    let decoded_calldata = hex::decode(calldata).expect("unable to decode calldata");
-    let first4bytes = &decoded_calldata[..4];
-
-    suspicous_func_selectors.iter().any(|s| s == first4bytes)
-}
-
-#[cfg(test)]
-mod suspicious_func_selector_tests {
-
-    use super::*;
-
-    #[test]
-    fn test_func_selector() {
-        // cast calldata "changeThreshold(uint256)" 12314
-        let threshold_changing_calldata =
-            "0x694e80c3000000000000000000000000000000000000000000000000000000000000301a";
-
-        assert!(is_suspicous_calldata(threshold_changing_calldata.to_string()));
-    }
 }

--- a/test/client_msg_response.json
+++ b/test/client_msg_response.json
@@ -1,0 +1,90 @@
+{
+    "messageHash": "0xd29cc2a8ce604f0cea069a545437fa79758062d093de335d73378ac76f6508d0",
+    "status": "NEEDS_CONFIRMATION",
+    "logoUri": null,
+    "name": null,
+    "message": {
+      "types": {
+        "Vote": [
+          {
+            "name": "from",
+            "type": "address"
+          },
+          {
+            "name": "space",
+            "type": "string"
+          },
+          {
+            "name": "timestamp",
+            "type": "uint64"
+          },
+          {
+            "name": "proposal",
+            "type": "bytes32"
+          },
+          {
+            "name": "choice",
+            "type": "uint32"
+          },
+          {
+            "name": "reason",
+            "type": "string"
+          },
+          {
+            "name": "app",
+            "type": "string"
+          },
+          {
+            "name": "metadata",
+            "type": "string"
+          }
+        ],
+        "EIP712Domain": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "type": "string"
+          }
+        ]
+      },
+      "domain": {
+        "name": "snapshot",
+        "version": "0.1.4"
+      },
+      "message": {
+        "app": "snapshot",
+        "from": "0x1c694fc3006d81ff4a56f97e1b99529066a23725",
+        "space": "beanstalkdao.eth",
+        "choice": "1",
+        "reason": "",
+        "metadata": "{}",
+        "proposal": "0x07157c4eacf799f34d340df37ab854c8fc1a9867dec53a36488fefd4aee597dd",
+        "timestamp": "1708620648"
+      },
+      "primaryType": "Vote"
+    },
+    "creationTimestamp": 1708620657823,
+    "modifiedTimestamp": 1708620751476,
+    "confirmationsSubmitted": 1,
+    "confirmationsRequired": 2,
+    "proposedBy": {
+      "value": "0xAF43958ad62389BE3E0B553dFd259Ec335814c1C",
+      "name": null,
+      "logoUri": null
+    },
+    "confirmations": [
+      {
+        "owner": {
+          "value": "0x53A26f48ED901336D7C165B85E6F43d9F8dBeAA7",
+          "name": null,
+          "logoUri": null
+        },
+        "signature": "0xe8cb7f10157253c53c9ae300a518252f747e81a9af2ec339283f51ca65704daf4b6ca774e1c63dcfc808231aeaae6b187099a479a3e36d6ea0a426d42a7872b81c"
+      }
+    ],
+    "preparedSignature": null,
+    "origin": "{}"
+}

--- a/test/client_tx_response.json
+++ b/test/client_tx_response.json
@@ -1,0 +1,71 @@
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "safe": "0x1c694Fc3006D81ff4a56F97E1b99529066a23725",
+            "to": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            "value": "0",
+            "data": "0xa9059cbb00000000000000000000000092d0ebaf7eb707f0650f9471e61348f4656c29bc00000000000000000000000000000000000000000000000000000005d21dba00",
+            "dataDecoded": {
+                "method": "transfer",
+                "parameters": [
+                    {
+                        "name": "to",
+                        "type": "address",
+                        "value": "0x92D0eBAF7Eb707F0650F9471E61348f4656c29bC",
+                        "valueDecoded": null
+                    },
+                    {
+                        "name": "value",
+                        "type": "uint256",
+                        "value": "25000000000",
+                        "valueDecoded": null
+                    }
+                ]
+            },
+            "operation": 0,
+            "gasToken": "0x0000000000000000000000000000000000000000",
+            "safeTxGas": 0,
+            "baseGas": 0,
+            "gasPrice": "0",
+            "proposer": "0xc12F6A2D93C0788366FC91aeBf21b33CCCb0c0d8",
+            "proposedByDelegate": null,
+            "refundReceiver": "0x0000000000000000000000000000000000000000",
+            "nonce": 63,
+            "executionDate": "2025-02-11T17:48:23.000Z",
+            "submissionDate": "2025-02-11T16:55:32.754Z",
+            "modified": "2025-02-11T17:48:26.483Z",
+            "blockNumber": 21824870,
+            "transactionHash": "0x37cdcc5f16e46682e417cff1ae61b02814fba8b0cdac5d3655f4e9bbda62c3e0",
+            "safeTxHash": "0xad06b099fca34e51e4886643d95d9a19ace2cd024065efb66662a876e8c40343",
+            "executor": "0xAF43958ad62389BE3E0B553dFd259Ec335814c1C",
+            "isExecuted": true,
+            "isSuccessful": true,
+            "ethGasPrice": "1331953884",
+            "gasUsed": 83624,
+            "fee": "111383311595616",
+            "origin": "{}",
+            "confirmationsRequired": 2,
+            "confirmations": [
+                {
+                    "owner": "0xc12F6A2D93C0788366FC91aeBf21b33CCCb0c0d8",
+                    "submissionDate": "2025-02-11T16:55:32.804Z",
+                    "transactionHash": null,
+                    "signatureType": "ETH_SIGN",
+                    "signature": "0xe5b5c20fa48b0633e35b044da59b43d86a20083f050307195f416ec7de4cae2728eb2773194b2fe39806d78f1398d2d775837cad077055d8bd60947b51aef3531f"
+                },
+                {
+                    "owner": "0xAF43958ad62389BE3E0B553dFd259Ec335814c1C",
+                    "submissionDate": "2025-02-11T17:45:03.858Z",
+                    "transactionHash": null,
+                    "signatureType": "ETH_SIGN",
+                    "signature": "0x250b73a9ef806089dc55c1ac978a55fcf8a580cfc9984e41d10e5e0990cade2f217213bd70d69856b99a64cebd47bf552144000246aa604791adaa514734268720"
+                }
+            ],
+            "signatures": "0x250b73a9ef806089dc55c1ac978a55fcf8a580cfc9984e41d10e5e0990cade2f217213bd70d69856b99a64cebd47bf552144000246aa604791adaa514734268720e5b5c20fa48b0633e35b044da59b43d86a20083f050307195f416ec7de4cae2728eb2773194b2fe39806d78f1398d2d775837cad077055d8bd60947b51aef3531f",
+            "trusted": true
+        }
+    ]
+}


### PR DESCRIPTION
With this PR, we are introducing calling out to an API to retrieve the details of a transaction. This PR introduces only the Client API, not the Transaction API because it is still returning 404 errors.

Follow-ups:
* PR is needed to default to the transaction API, and fallback on the Client API
* PR to retrieve message signing details from both Client API and Transaction API
