### PR TITLE
CI: decline-openssl

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -46,6 +46,4 @@ jobs:
 
       - name: Run tests
         run: |
-          cargo build
-          cargo install cargo-tree
           ! cargo tree -i openssl --target all

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -25,3 +25,26 @@ jobs:
         run: |
           cargo build
           cargo test -- --nocapture
+
+  decline-openssl-dependencies:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Install Rust Nightly (2025-01-01)
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2025-01-01
+          override: true
+
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+
+      - name: Restore Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: |
+          cargo install cargo-tree
+          ! cargo tree -i openssl --target all

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -27,7 +27,7 @@ jobs:
           cargo test -- --nocapture
 
   decline-openssl-dependencies:
-    name: Tests
+    name: Decline openssl
     runs-on: ubuntu-latest
     steps:
 
@@ -46,5 +46,6 @@ jobs:
 
       - name: Run tests
         run: |
+          cargo build
           cargo install cargo-tree
           ! cargo tree -i openssl --target all


### PR DESCRIPTION
Stop any dependency on  `openssl` from getting in. 
(Otherwise it will cause problems when building binaries)

cc : @alexroan 